### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/knutwalker/sessionizer/compare/v0.1.1...v0.1.2) - 2024-01-12
+
+### Other
+- Run an init file when a new session is created
+- release ([#2](https://github.com/knutwalker/sessionizer/pull/2))
+- Set correct category slug
+- release ([#1](https://github.com/knutwalker/sessionizer/pull/1))
+- Use variable directly
+- Publish
+- Use released versions
+- optional initial query
+- Improve cargo usage
+- Use fuzzy-select
+- init
+
 ## [0.1.1](https://github.com/knutwalker/sessionizer/compare/v0.1.0...v0.1.1) - 2024-01-09
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sessionizer"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 repository = "https://github.com/knutwalker/sessionizer"
 authors = ["Paul Horn <developer@knutwalker.de>"]


### PR DESCRIPTION
## 🤖 New release
* `sessionizer`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/knutwalker/sessionizer/compare/v0.1.1...v0.1.2) - 2024-01-12

### Other
- Run an init file when a new session is created
- release ([#2](https://github.com/knutwalker/sessionizer/pull/2))
- Set correct category slug
- release ([#1](https://github.com/knutwalker/sessionizer/pull/1))
- Use variable directly
- Publish
- Use released versions
- optional initial query
- Improve cargo usage
- Use fuzzy-select
- init
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).