### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,41 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.1.4](https://github.com/knutwalker/sessionizer/compare/0.1.3...0.1.4) - 2024-02-10
 
+
+- Add release-plz config ([#10](https://github.com/knutwalker/sessionizer/pull/10))
+
+- Move everything into a lib ([#9](https://github.com/knutwalker/sessionizer/pull/9))
+
+- Make clap types and fields pub ([#8](https://github.com/knutwalker/sessionizer/pull/8))
+
+- Stricter permission checks for init files ([#7](https://github.com/knutwalker/sessionizer/pull/7))
+
+- Run session initialization from a toml file ([#5](https://github.com/knutwalker/sessionizer/pull/5))
+
+- Add --select-1 equivalent
+
+- Collect all trailing args into the initial query
+
+- Run an init file when a new session is created
+
+- Set correct category slug
+
+- Use variable directly
+
+- Publish
+
+- Use released versions
+
+- optional initial query
+
+- Improve cargo usage
+
+- Use fuzzy-select
+
+- init
+"#;
 ## [0.1.3](https://github.com/knutwalker/sessionizer/compare/v0.1.2...v0.1.3) - 2024-01-15
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sessionizer"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 repository = "https://github.com/knutwalker/sessionizer"
 authors = ["Paul Horn <developer@knutwalker.de>"]


### PR DESCRIPTION
## 🤖 New release
* `sessionizer`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/knutwalker/sessionizer/compare/0.1.3...0.1.4) - 2024-02-10

- Add release-plz config ([#10](https://github.com/knutwalker/sessionizer/pull/10))

- Move everything into a lib ([#9](https://github.com/knutwalker/sessionizer/pull/9))

- Make clap types and fields pub ([#8](https://github.com/knutwalker/sessionizer/pull/8))

- Stricter permission checks for init files ([#7](https://github.com/knutwalker/sessionizer/pull/7))

- Run session initialization from a toml file ([#5](https://github.com/knutwalker/sessionizer/pull/5))

- Add --select-1 equivalent

- Collect all trailing args into the initial query

- Run an init file when a new session is created

- Set correct category slug

- Use variable directly

- Publish

- Use released versions

- optional initial query

- Improve cargo usage

- Use fuzzy-select

- init
"#;
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).