### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [0.1.5](https://github.com/knutwalker/sessionizer/compare/0.1.4...0.1.5) - 2024-02-10
+## [0.1.6](https://github.com/knutwalker/sessionizer/compare/0.1.5...0.1.6) - 2024-02-10## [0.1.5](https://github.com/knutwalker/sessionizer/compare/0.1.4...0.1.5) - 2024-02-10
 ### Changes
 
 - Update readme

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sessionizer"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.75.0"
 repository = "https://github.com/knutwalker/sessionizer"


### PR DESCRIPTION
## 🤖 New release
* `sessionizer`: 0.1.5 -> 0.1.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/knutwalker/sessionizer/compare/0.1.5...0.1.6) - 2024-02-10## [0.1.5](https://github.com/knutwalker/sessionizer/compare/0.1.4...0.1.5) - 2024-02-10

### Changes

- Update readme
- Update release-plz config
- Fix changelog
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).