### PR TITLE
chore: release v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.6](https://github.com/knutwalker/sessionizer/compare/0.1.5...0.1.6) - 2024-02-17
+
+### Changes
+
+- Set $SESSION_ based env vars in a newly spawned tmux session
+- Update changelog to remove newlines between items
+- Update changelog template yet again
+- Unignore tags files/folders
+- Update changelog again
+- Fix changelog
+- Update changelog template
+
 ## [0.1.5](https://github.com/knutwalker/sessionizer/compare/0.1.4...0.1.5) - 2024-02-10
 
 ### Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sessionizer"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 rust-version = "1.75.0"
 repository = "https://github.com/knutwalker/sessionizer"


### PR DESCRIPTION
## 🤖 New release
* `sessionizer`: 0.1.5 -> 0.1.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.6](https://github.com/knutwalker/sessionizer/compare/0.1.5...0.1.6) - 2024-02-17

### Changes

- Set $SESSION_ based env vars in a newly spawned tmux session
- Update changelog to remove newlines between items
- Update changelog template yet again
- Unignore tags files/folders
- Update changelog again
- Fix changelog
- Update changelog template
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).