### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1](https://github.com/knutwalker/sessionizer/compare/0.2.0...0.2.1) - 2024-06-11
+
+### Changes
+
+- Don't log warning when tmux is not running ([#23](https://github.com/knutwalker/sessionizer/pull/23))
+- Apply simple variable expansion for env vars ([#21](https://github.com/knutwalker/sessionizer/pull/21))
+
 ## [0.2.0](https://github.com/knutwalker/sessionizer/compare/0.1.6...0.2.0) - 2024-06-07
 
 ### Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sessionizer"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.75.0"
 repository = "https://github.com/knutwalker/sessionizer"


### PR DESCRIPTION
## 🤖 New release
* `sessionizer`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/knutwalker/sessionizer/compare/0.2.0...0.2.1) - 2024-06-11

### Changes

- Don't log warning when tmux is not running ([#23](https://github.com/knutwalker/sessionizer/pull/23))
- Apply simple variable expansion for env vars ([#21](https://github.com/knutwalker/sessionizer/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).