### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.2](https://github.com/knutwalker/sessionizer/compare/0.2.1...0.2.2) - 2024-06-21
+## [0.3.0](https://github.com/knutwalker/sessionizer/compare/0.2.1...0.3.0) - 2024-06-21
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2](https://github.com/knutwalker/sessionizer/compare/0.2.1...0.2.2) - 2024-06-21
+
+### Changes
+
+- Allow the configuration of the search path ([#28](https://github.com/knutwalker/sessionizer/pull/28))
+- Reduce dependencies surface, esp. regarding syn ([#26](https://github.com/knutwalker/sessionizer/pull/26))
+
 ## [0.2.1](https://github.com/knutwalker/sessionizer/compare/0.2.0...0.2.1) - 2024-06-11
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "sessionizer"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "bytecount",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "sessionizer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bytecount",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sessionizer"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.75.0"
 repository = "https://github.com/knutwalker/sessionizer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sessionizer"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.75.0"
 repository = "https://github.com/knutwalker/sessionizer"


### PR DESCRIPTION
## 🤖 New release
* `sessionizer`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/knutwalker/sessionizer/compare/0.2.1...0.2.2) - 2024-06-21

### Changes

- Allow the configuration of the search path ([#28](https://github.com/knutwalker/sessionizer/pull/28))
- Reduce dependencies surface, esp. regarding syn ([#26](https://github.com/knutwalker/sessionizer/pull/26))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).