### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2](https://github.com/knutwalker/sessionizer/compare/0.3.1...0.3.2) - 2024-06-21
+
+### Changes
+
+- Don't require a git repo for build files ([#31](https://github.com/knutwalker/sessionizer/pull/31))
+
 ## [0.3.1](https://github.com/knutwalker/sessionizer/compare/0.3.0...0.3.1) - 2024-06-21
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,7 +949,7 @@ dependencies = [
 
 [[package]]
 name = "sessionizer"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bytecount",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sessionizer"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 rust-version = "1.75.0"
 repository = "https://github.com/knutwalker/sessionizer"


### PR DESCRIPTION
## 🤖 New release
* `sessionizer`: 0.3.1 -> 0.3.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/knutwalker/sessionizer/compare/0.3.1...0.3.2) - 2024-06-21

### Changes

- Don't require a git repo for build files ([#31](https://github.com/knutwalker/sessionizer/pull/31))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).