### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0](https://github.com/knutwalker/sessionizer/compare/0.4.0...0.5.0) - 2024-09-05
+
+### Changes
+
+- Add an actual config over a path env variable ([#44](https://github.com/knutwalker/sessionizer/pull/44))
+
 ## [0.4.0](https://github.com/knutwalker/sessionizer/compare/0.3.5...0.4.0) - 2024-09-05
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "sessionizer"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytecount",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sessionizer"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.75.0"
 repository = "https://github.com/knutwalker/sessionizer"


### PR DESCRIPTION
## 🤖 New release
* `sessionizer`: 0.4.0 -> 0.5.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/knutwalker/sessionizer/compare/0.4.0...0.5.0) - 2024-09-05

### Changes

- Add an actual config over a path env variable ([#44](https://github.com/knutwalker/sessionizer/pull/44))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).