### PR TITLE
chore: release v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4](https://github.com/knutwalker/sessionizer/compare/0.6.3...0.6.4) - 2025-04-03
+
+### Changes
+
+- The --config commands operate on the session root by default ([#62](https://github.com/knutwalker/sessionizer/pull/62))
+- Smaller clippy updates ([#61](https://github.com/knutwalker/sessionizer/pull/61))
+
 ## [0.6.3](https://github.com/knutwalker/sessionizer/compare/0.6.2...0.6.3) - 2025-04-02
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "sessionizer"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "bytecount",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sessionizer"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2024"
 rust-version = "1.85.0"
 repository = "https://github.com/knutwalker/sessionizer"


### PR DESCRIPTION



## 🤖 New release

* `sessionizer`: 0.6.3 -> 0.6.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.4](https://github.com/knutwalker/sessionizer/compare/0.6.3...0.6.4) - 2025-04-03

### Changes

- The --config commands operate on the session root by default ([#62](https://github.com/knutwalker/sessionizer/pull/62))
- Smaller clippy updates ([#61](https://github.com/knutwalker/sessionizer/pull/61))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).