### PR TITLE
chore: release v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.5](https://github.com/knutwalker/sessionizer/compare/0.6.4...0.6.5) - 2025-11-12
+
+### Changes
+
+- Allow search args for the --shell command ([#64](https://github.com/knutwalker/sessionizer/pull/64))
+
 ## [0.6.4](https://github.com/knutwalker/sessionizer/compare/0.6.3...0.6.4) - 2025-04-03
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "sessionizer"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "bytecount",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sessionizer"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2024"
 rust-version = "1.85.0"
 repository = "https://github.com/knutwalker/sessionizer"


### PR DESCRIPTION



## 🤖 New release

* `sessionizer`: 0.6.4 -> 0.6.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.5](https://github.com/knutwalker/sessionizer/compare/0.6.4...0.6.5) - 2025-11-12

### Changes

- Allow search args for the --shell command ([#64](https://github.com/knutwalker/sessionizer/pull/64))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).